### PR TITLE
fix choco_update action

### DIFF
--- a/choco/blenderbim/check_repo_infos.py
+++ b/choco/blenderbim/check_repo_infos.py
@@ -70,7 +70,7 @@ elif sys.argv[1] == "--pyver?":
     found = re.findall(re_blender_version_min_maj_pat, html_txt)
     if found:
         latest_blender_version_tag = f"v{found[0]}"
-        re_blender_python_version_maj_min = r"SET\(PYTHON_VERSION (\d+.\d+) "
+        re_blender_python_version_maj_min = r"^SET\(_PYTHON_VERSION_SUPPORTED (\d+\.\d+)\)$"
         url = f"https://raw.githubusercontent.com/blender/blender/{latest_blender_version_tag}/build_files/cmake/Modules/FindPythonLibsUnix.cmake"
         resp = request_repo_info(url)
         html_txt = str(resp.read())


### PR DESCRIPTION
@Moult this should bring the choco updater back on track. 
it apparently got interrupted 2023-06-26
fix is according to blender upstream makefile change: 
https://github.com/blender/blender/blob/main/build_files/cmake/Modules/FindPythonLibsUnix.cmake